### PR TITLE
Update en version docs for File.Recalc, RecalcCell, RecalcOptions, ErrCellNoFormula, and 3D range support

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -118,6 +118,8 @@
   * [Set cell formula](cell.md#SetCellFormula)
   * [Get cell formula](cell.md#GetCellFormula)
   * [Calculate cell value](cell.md#CalcCellValue)
+  * [Recalculate formula cell](cell.md#RecalcCell)
+  * [Recalculate workbook](cell.md#Recalc)
 * [Chart](chart.md)
   * [Add chart](chart.md#AddChart)
   * [Add chart sheet](chart.md#AddChartSheet)

--- a/en/cell.md
+++ b/en/cell.md
@@ -27,6 +27,15 @@ type FormulaOpts struct {
 }
 ```
 
+`RecalcOptions` can be passed to [`Recalc`](cell.md#Recalc) to narrow the recalculation to a specific worksheet or an A1-style range.
+
+```go
+type RecalcOptions struct {
+    Sheet string // Limit recalc to a single worksheet when non-empty
+    Ref   string // Limit recalc to the given A1-style range (requires Sheet)
+}
+```
+
 ## Set cell value {#SetCellValue}
 
 ```go
@@ -761,6 +770,8 @@ func (f *File) CalcCellValue(sheet, cell string, opts ...Options) (string, error
 
 CalcCellValue provides a function to get calculated cell value. This feature is currently in working processing. Iterative calculation, implicit intersection, explicit intersection, array formula, table formula and some other formulas are not supported currently.
 
+3D references across a contiguous workbook-order range of worksheets are supported for the unquoted-name shape, for example `SUM(Jan:Mar!A1)` or `SUM(Jänner:Dezember!$M$40)`. The aggregates `SUM`, `AVERAGE`, `MIN`, `MAX`, `COUNT`, `COUNTA`, and `PRODUCT` consume the expanded matrix. A reversed or missing sheet name in the 3D range resolves to `#REF!`.
+
 Supported formulas:
 
 Function name | Description
@@ -1220,3 +1231,39 @@ YIELDDISC                | Returns the annual yield for a discounted security; f
 YIELDMAT                 | Returns the annual yield of a security that pays interest at maturity
 Z.TEST                   | Returns the one-tailed probability-value of a z-test
 ZTEST                    | Returns the one-tailed probability-value of a z-test
+
+## Recalculate formula cell {#RecalcCell}
+
+```go
+func (f *File) RecalcCell(sheet, cell string) error
+```
+
+RecalcCell evaluates the formula in the given cell and persists the typed result into the cell's cached `<v>`/`<t>` pair without touching `<f>` or any shared-formula grouping (`ref`, `si`). Downstream readers that rely on the cached value without recomputing the formula themselves (for example LibreOffice headless or Apple Numbers) will see the up-to-date result after a round trip through the library.
+
+Dependency resolution uses the same recursive evaluator as [`CalcCellValue`](cell.md#CalcCellValue), so a single call converges a chain of formulas that feed the target. Circular references are bounded by the workbook's `MaxCalcIterations` option.
+
+Returns `ErrCellNoFormula` when the target cell does not hold a formula.
+
+## Recalculate workbook {#Recalc}
+
+```go
+func (f *File) Recalc(opts ...RecalcOptions) error
+```
+
+Recalc evaluates every formula in scope and persists each result into the cell's cached `<v>`/`<t>` via [`RecalcCell`](cell.md#RecalcCell). The `<f>` element and any shared-formula grouping are preserved. The typical use is the open-mutate-save round trip:
+
+```go
+f, _ := excelize.OpenFile("book.xlsx")
+defer func() { _ = f.Close() }()
+_ = f.Recalc()
+_ = f.Save()
+```
+
+The default (no options) walks the whole workbook. Pass a [`RecalcOptions`](cell.md) value to narrow the sweep: `Sheet` limits recalc to one worksheet; `Ref` (which requires `Sheet`) limits it further to an A1-style range such as `B2:D10`.
+
+```go
+_ = f.Recalc(excelize.RecalcOptions{Sheet: "Summary"})
+_ = f.Recalc(excelize.RecalcOptions{Sheet: "Summary", Ref: "B2:D10"})
+```
+
+When any formula cannot be evaluated, Recalc continues with the remaining cells and returns `errors.Join` over per-cell failures wrapped as `fmt.Errorf("<sheet>!<cell>: %w", cause)`. Use `errors.Is` or `errors.As` to descend into the underlying causes. Cells that did compute are still persisted.

--- a/en/variables.md
+++ b/en/variables.md
@@ -8,6 +8,8 @@ var (
     ErrAttrValBool = errors.New("unexpected child of attrValBool")
     // ErrCellCharsLength defined the error message for receiving a cell characters length that exceeds the limit.
     ErrCellCharsLength = fmt.Errorf("cell value must be 0-%d characters", TotalCellChars)
+    // ErrCellNoFormula defined the error message on attempting to refresh the cached value of a cell that does not hold a formula.
+    ErrCellNoFormula = errors.New("cell does not contain a formula")
     // ErrCellStyles defined the error message on cell styles exceeds the limit.
     ErrCellStyles = fmt.Errorf("the cell styles exceeds the %d limit", MaxCellStyles)
     // ErrColumnNumber defined the error message on receive an invalid column number.


### PR DESCRIPTION
## Description

Adds reference entries to the English docs for the new public surface introduced in the companion xuri/excelize PRs under umbrella issue xuri/excelize#2303:

- `RecalcOptions` type prose and code block in `en/cell.md` (alongside `FormulaOpts`)
- `Recalculate formula cell` section documenting `RecalcCell`
- `Recalculate workbook` section documenting `Recalc` (with scoping examples)
- `ErrCellNoFormula` entry in `en/variables.md`
- A short note on 3D-range support in the `Calculate cell value` section
- Two new navigation entries in `en/SUMMARY.md`

Only the English version is touched here, matching the project's usual rollout cadence (other language versions are typically propagated by the maintainer after the en version lands).

## Related Issue

Tracks the same umbrella as the excelize code PRs:

- xuri/excelize#2303 — umbrella
- xuri/excelize#2310 — 3D references across sheet ranges
- xuri/excelize#2311 — `RecalcCell` + `ErrCellNoFormula` (closes xuri/excelize#2307)
- xuri/excelize#2312 — `Recalc` whole-workbook (closes xuri/excelize#2303)
- xuri/excelize#2313 — `RecalcOptions` scoping (closes xuri/excelize#2308)

## Motivation and Context

Every new exported symbol introduced by those PRs — `RecalcCell`, `Recalc`, `RecalcOptions`, `ErrCellNoFormula` — needs reference prose on the docs site. The 3D-range extension to `CalcCellValue` likewise deserves a note so users know which aggregates understand the new shape. Without these entries, the PRs cannot truthfully tick the "documentation updated" checkbox.